### PR TITLE
Telephony : Ensure private numbers are blocked if block unknown numbe…

### DIFF
--- a/src/java/com/android/internal/telephony/util/BlacklistUtils.java
+++ b/src/java/com/android/internal/telephony/util/BlacklistUtils.java
@@ -94,6 +94,14 @@ public class BlacklistUtils {
             return MATCH_NONE;
         }
 
+        if (isBlacklistUnknownNumberEnabled(context, mode)) {
+            CallerInfo ci = CallerInfo.getCallerInfo(context, number);
+            if (ci == null || !ci.contactExists) {
+                if (DEBUG) Log.d(TAG, "Blacklist matched due to unknown number");
+                return MATCH_UNKNOWN;
+            }
+        }
+
         // Private and unknown number matching
         if (TextUtils.isEmpty(number)) {
             if (isBlacklistPrivateNumberEnabled(context, mode)) {
@@ -101,14 +109,6 @@ public class BlacklistUtils {
                 return MATCH_PRIVATE;
             }
             return MATCH_NONE;
-        }
-
-        if (isBlacklistUnknownNumberEnabled(context, mode)) {
-            CallerInfo ci = CallerInfo.getCallerInfo(context, number);
-            if (!ci.contactExists) {
-                if (DEBUG) Log.d(TAG, "Blacklist matched due to unknown number");
-                return MATCH_UNKNOWN;
-            }
         }
 
         Uri.Builder builder = Blacklist.CONTENT_FILTER_BYNUMBER_URI.buildUpon();


### PR DESCRIPTION
…rs is enabled

When a private number comes through, its value is either null or empty.
Make sure that if the user has blocking of unknown numbers enabled, that its blocked

Change-Id: Ica629215f584572c701fd10464d8828c3f099694